### PR TITLE
Thunderboard 2 config files

### DIFF
--- a/src/boards/thunderboard2/retargeti2cconfig.h
+++ b/src/boards/thunderboard2/retargeti2cconfig.h
@@ -1,0 +1,21 @@
+// Sample I2C configuration for Silicon Labs Thunderboard 2.
+
+// Source: https://www.silabs.com/documents/public/data-sheets/efr32mg12-datasheet.pdf
+
+#ifndef RETARGETI2CCONFIG_H_
+#define RETARGETI2CCONFIG_H_
+
+#define RETARGET_I2C_DEV         I2C1
+#define RETARGET_I2C_CLOCK       cmuClock_I2C1
+
+#define RETARGET_I2C_SDA_PORT    gpioPortC
+#define RETARGET_I2C_SDA_PIN     4
+#define RETARGET_I2C_SCL_PORT    gpioPortC
+#define RETARGET_I2C_SCL_PIN     5
+#define RETARGET_I2C_PWR_PORT    gpioPortF
+#define RETARGET_I2C_PWR_PIN     9
+
+#define RETARGET_I2C_SDA_LOC     I2C_ROUTELOC0_SDALOC_LOC17 
+#define RETARGET_I2C_SCL_LOC     I2C_ROUTELOC0_SCLLOC_LOC17  
+
+#endif//RETARGETI2CCONFIG_H_

--- a/src/boards/thunderboard2/retargetspiconfig.h
+++ b/src/boards/thunderboard2/retargetspiconfig.h
@@ -1,0 +1,22 @@
+// Sample SPI configuration for Silicon Labs Thunderboard 2
+
+// Source: https://www.silabs.com/documents/public/schematic-files/TBSense2-BRD4166A-D00-schematic.pdf
+
+#ifndef RETARGETSPICONFIG_H_
+#define RETARGETSPICONFIG_H_
+
+#define RETARGET_SPI_UART      USART2
+#define RETARGET_SPI_CLOCK     cmuClock_USART2
+#define RETARGET_SPI_MISO_PORT gpioPortK
+#define RETARGET_SPI_MISO_PIN  2
+#define RETARGET_SPI_MOSI_PORT gpioPortK
+#define RETARGET_SPI_MOSI_PIN  0
+#define RETARGET_SPI_SCK_PORT  gpioPortF
+#define RETARGET_SPI_SCK_PIN   7
+#define RETARGET_SPI_CS_PORT   gpioPortK
+#define RETARGET_SPI_CS_PIN    1
+#define RETARGET_SPI_RX_LOC    USART_ROUTELOC0_RXLOC_LOC30
+#define RETARGET_SPI_TX_LOC    USART_ROUTELOC0_TXLOC_LOC29
+#define RETARGET_SPI_CLK_LOC   USART_ROUTELOC0_CLKLOC_LOC18 
+
+#endif//RETARGETSPICONFIG_H_


### PR DESCRIPTION
Added retarget spi and retarget i2c config files for the Thunderboard 2, required to run dataflash and i2c-scan apps from the node-apps repo.

Sources:
- [Thunderboard 2 schematics](https://www.silabs.com/documents/public/schematic-files/TBSense2-BRD4166A-D00-schematic.pdf)
- [Thunderboard 2 user guide](https://www.silabs.com/documents/public/user-guides/ug309-sltb004a-user-guide.pdf)
